### PR TITLE
fix: drop-shadow flickering on iOS Safari

### DIFF
--- a/components/ActionButton.tsx
+++ b/components/ActionButton.tsx
@@ -31,6 +31,7 @@ export class ActionButton extends Component<ActionButton.Props> {
             outline-color: var(--bg);
             color: var(--fg);
             filter: var(--drop-shadow);
+            will-change: filter;
             border-radius: 1.5rem;
             margin: 0.5rem;
             padding: 0;

--- a/components/ColorMixer.tsx
+++ b/components/ColorMixer.tsx
@@ -47,6 +47,7 @@ export class ColorMixer extends Component<{ class?: string }> {
                 clip-path: circle(var(--reveal) at 85% 88%);
                 border-radius: 1rem;
                 filter: var(--drop-shadow);
+                will-change: filter;
                 transition-behavior: allow-discrete;
                 transition-duration: 250ms;
                 transition-property: background-color, clip-path, display, filter;


### PR DESCRIPTION
# Before:
https://github.com/user-attachments/assets/2ece43b8-f5eb-4c51-859f-84c56a77ae8f

# After:

https://github.com/user-attachments/assets/b4dde904-2db2-49ef-a150-982fb0e9dd74

